### PR TITLE
Remove unused variable

### DIFF
--- a/docs/config-example.md
+++ b/docs/config-example.md
@@ -12,7 +12,6 @@ retries = 5
 
 [plugin1]
 k8s_conf_path = /home/user/.kube/config
-visualizer_type = plugin1
 visualizer_ip = 127.0.0.1
 
 [datasource1]

--- a/visualizer.cfg
+++ b/visualizer.cfg
@@ -8,7 +8,6 @@ retries = 5
 
 [k8s-grafana]
 k8s_conf_path = /home/user/.kube/config
-visualizer_type = <visualizer_type>
 visualizer_ip = <ip_of_the_visualizer>
 
 [monasca]

--- a/visualizer/plugins/k8s_grafana/plugin.py
+++ b/visualizer/plugins/k8s_grafana/plugin.py
@@ -53,8 +53,6 @@ class K8sGrafanaProgress(Plugin):
         else:
             raise Exception("ERROR: Datasource type unknown...!")
 
-        self.visualizer_type = api.visualizer_type
-
         # Gets the visualizer ip if the value is not explicitic in the config
         # file
         try:

--- a/visualizer/service/api/__init__.py
+++ b/visualizer/service/api/__init__.py
@@ -52,8 +52,6 @@ try:
             if(config.has_option('k8s-grafana', 'visualizer_ip')):
                 visualizer_ip = config.get("k8s-grafana", "visualizer_ip")
 
-        visualizer_type = config.get("k8s-grafana", "visualizer_type")
-
     for datasource in datasources:
 
         """ Validate if really exists a section to the datasource """


### PR DESCRIPTION
This PR resolve the issue #15 
- Remove unused variable "visualizer_type" from API
- Remove API call of variable above in k8s-grafana plugin
- Remove "visualizer_type" variable from config examples (visualizer.cfg and config-example.md)

